### PR TITLE
Fix Event.write to have writable = true

### DIFF
--- a/src/event.ml
+++ b/src/event.ml
@@ -5,5 +5,5 @@ type t =
 
 let read = { readable = true; writable = false }
 let none = { readable = false; writable = false }
-let write = { readable = false; writable = false }
+let write = { readable = false; writable = true }
 let read_write = { readable = true; writable = true }


### PR DESCRIPTION
I was testing the library and my code got "stuck", I tried using `Poll.set mux socket Poll.Event.write`  to handle `EINPROGRESS` from `connect`, but `strace` was showing that the FD was not getting added to the epoll set.
This was because the code thought no change was requested, since `Event.write` was equal to `Event.none`.